### PR TITLE
Added and used parameter disable_firewall

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class xldeploy::params {
   $enable_housekeeping        = true
   $java_home                  = '/usr/lib/jvm/jre-1.7.0-openjdk.x86_64'
   $install_java               = false
-
+  $disable_firewall           = true
 
   #security settings
   $xldeploy_authentication_providers = {'rememberMeAuthenticationProvider' => 'com.xebialabs.deployit.security.authentication.RememberMeAuthenticationProvider',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -67,6 +67,7 @@ class xldeploy::server (
   $gem_use_local                     = $xldeploy::params::gem_use_local,
   $gem_hash                          = $xldeploy::params::gem_hash,
   $gem_array                         = $xldeploy::params::gem_array,
+  $disable_firewall                  = $xldeploy::params::disable_firewall,
   $server_plugins                    = { },
   $cis                               = { } ,
   $memberships                       = { } ,

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -21,7 +21,8 @@ class xldeploy::server::install (
   $install_license             = $xldeploy::server::install_license,
   $license_source              = $xldeploy::server::license_source,
   $productname                 = $xldeploy::server::productname,
-  $server_plugins              = $xldeploy::server::server_plugins
+  $server_plugins              = $xldeploy::server::server_plugins,
+  $disable_firewall            = $xldeploy::server::disable_firewall
 ) {
 
   # Variables
@@ -88,13 +89,16 @@ class xldeploy::server::install (
   }
 
   # check to see if where on a redhatty system and shut iptables down quicker than you can say wtf
-  if !defined(Service[iptables]) {
-    case $::osfamily {
-      'RedHat' : {
-        service { 'iptables': ensure => stopped }
-        Service['iptables'] -> File["/etc/${productname}", "/var/log/${productname}"]
-      }
-      default  : {
+  # only when disable_fireall is true 
+  if str2bool($disable_firewall) {
+    if !defined(Service[iptables]) {
+      case $::osfamily {
+        'RedHat' : {
+          service { 'iptables': ensure => stopped }
+          Service['iptables'] -> File["/etc/${productname}", "/var/log/${productname}"]
+        }
+        default  : {
+        }
       }
     }
   }

--- a/manifests/server/validation.pp
+++ b/manifests/server/validation.pp
@@ -50,6 +50,7 @@ class xldeploy::server::validation (
   validate_bool(str2bool($xldeploy::server::enable_housekeeping))
   validate_bool(str2bool($xldeploy::server::install_java))
   validate_bool(str2bool($xldeploy::server::client_propagate_key))
+  validate_bool(str2bool($xldeploy::server::disable_firewall))
 
   # hash validation
   validate_hash($xldeploy::server::cis)


### PR DESCRIPTION
Added extra check (with parameter disable_firewall) whether iptables should be stopped or not.

Context:
Using xldeploy module in combination with the customers puppet modules results in all ports being blocked and the only way of accessing the vm being the console. Also xldeploy will be not be installed successfully. By making the stopping of the iptables service optional xldeploy will be installed.

Environment:
Oracle Linux Server 6.5 (Red Hat Linux Server 6.5)
Puppet 3.5.1 (open source)
Server has no internet connection (direct or proxy).
