### PR TITLE
Enable fork hack

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -182,6 +182,11 @@ class xldeploy::server::config (
     }
   } else {
     Xldeploy_setup['default'] ->
+    ini_setting { 'forkhack':
+      path    => "${server_home_dir}/conf/xld-wrapper-linux.conf",
+      setting => 'wrapper.fork_hack',
+      value   => 'true',
+    } ->
     exec {"/bin/echo ${os_user}|${server_home_dir}/bin/install-service.sh":
       unless => "/usr/bin/test -f /etc/init.d/${productname}",
     }


### PR DESCRIPTION
Using JDK 8, install-service.sh succeeds, the service gets restarted but never starts properly. Using this yajsw property, starting the service always works.

Docs: http://yajsw.sourceforge.net/YAJSW%20Configuration%20Parameters.html
