### PR TITLE
Complete command without debug statements

### DIFF
--- a/templates/xldeploy-initd-RedHat.erb
+++ b/templates/xldeploy-initd-RedHat.erb
@@ -55,7 +55,7 @@ start() {
     echo
     exit 1
   else
-	/bin/su - $RUNNINGUSER -c 'export JAVA_HOME=<%= @java_home %>;/bin/sh <%= @server_home_dir %>/bin/server.sh
+	/bin/su - $RUNNINGUSER -c 'export JAVA_HOME=<%= @java_home %>;/bin/sh <%= @server_home_dir %>/bin/server.sh &' > /dev/null 2>&1
 	sleep 3
 	PID=$(ps -fu $RUNNINGUSER | grep $PROG | awk '{print $2}')
     if [ "$PID" != "" ]


### PR DESCRIPTION
3e2c2fdf3a236c868c63001edffac635724f55c7 breaks init script, too much removed.