### PR TITLE
fix corrupt cache yaml

### DIFF
--- a/lib/puppet/parser/functions/md5pass.rb
+++ b/lib/puppet/parser/functions/md5pass.rb
@@ -28,6 +28,7 @@ module Puppet::Parser::Functions
     # get the cache from file if the file exists
     cache = YAML.load_file('/var/tmp/md5pass_cache.yaml') if File.exists?(cache_file)
     cache = {} if cache == nil
+    cache = {} if cache == false
 
     result = cache[value] if cache.has_key?(value)
     result = `/usr/bin/openssl passwd -1 -salt #{salt} #{value}`.strip() if result == nil


### PR DESCRIPTION
If md5pass_cache.yaml exists but is invalid or has been corrupted the variable "cache" will contain the value false.
Once it reaches line 33 it will throw the error:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: {"message":"Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, undefined method `has_key?' for false:FalseClass at /etc/puppetlabs/code/environments/KT_sfpd_Test_Puppet_Modules_10/modules/xldeploy/manifests/client/user.pp:35:19 on node lts-pcp02.cloud.sfpd.fgov.be","issue_kind":"RUNTIME_ERROR","stacktrace":["Warning: The 'stacktrace' property is deprecated and will be removed in a future version of Puppet. For security reasons, stacktraces are not returned with Puppet HTTP Error responses."]}